### PR TITLE
Change Consul status conmmand

### DIFF
--- a/carbond
+++ b/carbond
@@ -195,7 +195,7 @@ case "$INPUT_1" in
         setup_vault
         setup_consul
         vault status
-        consul status
+        consul info
         ;;
 
 	restart)


### PR DESCRIPTION
This hotfix changes `consul status` to `consul info`.