### PR TITLE
Add sleep to allow time for initialization and unseal process

### DIFF
--- a/src/vault/setup_vault.sh
+++ b/src/vault/setup_vault.sh
@@ -107,13 +107,14 @@ vault_set_addr(){
     else
         printf '\n%s\n' "Vault environment already set!"
     fi
+
 }
 
 vault_set_addr
 vault_init
 sleep 2
-scrub_creds
 vault_unseal
 sleep 2
 vault_login
+scrub_creds
 output


### PR DESCRIPTION
This adds a sleep to the initialization and unseal process that increases the rate of success.